### PR TITLE
Update Error Messaging

### DIFF
--- a/src/modals/error-modal-content.ts
+++ b/src/modals/error-modal-content.ts
@@ -1,11 +1,4 @@
-import {
-  LitElement,
-  html,
-  css,
-  customElement,
-  CSSResult,
-  TemplateResult,
-} from 'lit-element';
+import { LitElement, html, css, customElement, CSSResult, TemplateResult } from 'lit-element';
 
 /**
  * This is shown at the bottom of the error modal.
@@ -20,7 +13,11 @@ export class ErrorModalContent extends LitElement {
   render(): TemplateResult {
     return html`
       <div class="container">
-        <a href="https://help.archive.org/hc/en-us/articles/360037568971-Why-is-there-a-problem-processing-my-donation-" target="_blank">
+        <a
+          href="https://help.archive.org/hc/en-us/articles/360037568971-Why-is-there-a-problem-processing-my-donation-"
+          rel="noopener"
+          target="_blank"
+        >
           Questions?
         </a>
       </div>
@@ -39,9 +36,11 @@ export class ErrorModalContent extends LitElement {
         text-align: center;
       }
 
-      a, a:link, a:visited {
+      a,
+      a:link,
+      a:visited {
         color: ${questionsLinkFontColor};
-        font-size: ${questionsLinkFontSize}
+        font-size: ${questionsLinkFontSize};
       }
     `;
   }

--- a/src/modals/error-modal-content.ts
+++ b/src/modals/error-modal-content.ts
@@ -1,0 +1,48 @@
+import {
+  LitElement,
+  html,
+  css,
+  customElement,
+  CSSResult,
+  TemplateResult,
+} from 'lit-element';
+
+/**
+ * This is shown at the bottom of the error modal.
+ *
+ * @export
+ * @class ErrorModalContent
+ * @extends {LitElement}
+ */
+@customElement('donation-form-error-modal-content')
+export class ErrorModalContent extends LitElement {
+  /** @inheritdoc */
+  render(): TemplateResult {
+    return html`
+      <div class="container">
+        <a href="https://help.archive.org/hc/en-us/articles/360037568971-Why-is-there-a-problem-processing-my-donation-" target="_blank">
+          Questions?
+        </a>
+      </div>
+    `;
+  }
+
+  /** @inheritdoc */
+  static get styles(): CSSResult {
+    const questionsLinkTopMargin = css`var(--errorModalQuestionsLinkTopMargin, 1rem)`;
+    const questionsLinkFontColor = css`var(--errorModalQuestionsLinkFontColor, #333)`;
+    const questionsLinkFontSize = css`var(--errorModalQuestionsLinkFontSize, 1.4rem)`;
+
+    return css`
+      .container {
+        margin-top: ${questionsLinkTopMargin};
+        text-align: center;
+      }
+
+      a, a:link, a:visited {
+        color: ${questionsLinkFontColor};
+        font-size: ${questionsLinkFontSize}
+      }
+    `;
+  }
+}

--- a/src/payment-flow-handlers/donation-flow-modal-manager.ts
+++ b/src/payment-flow-handlers/donation-flow-modal-manager.ts
@@ -160,17 +160,23 @@ export class DonationFlowModalManager implements DonationFlowModalManagerInterfa
   showErrorModal(options: { message: string; userClosedModalCallback?: () => void }): void {
     const modalConfig = new ModalConfig({
       headerColor: ModalHeaderColor.Red,
+      title: html`Processing error`,
       headline: html`
-        An Error Occurred
+        There's been a problem processing your donation.
       `,
       message: html`
         ${options?.message}
-      `,
+      `
     });
 
     this.modalManager.showModal({
       config: modalConfig,
       userClosedModalCallback: options?.userClosedModalCallback,
+      customModalContent: html`
+        <a href="https://help.archive.org/hc/en-us/articles/360037568971-Why-is-there-a-problem-processing-my-donation-" style="color: black">
+          Questions?
+        </a>
+      `
     });
   }
 

--- a/src/payment-flow-handlers/donation-flow-modal-manager.ts
+++ b/src/payment-flow-handlers/donation-flow-modal-manager.ts
@@ -250,7 +250,7 @@ export class DonationFlowModalManager implements DonationFlowModalManagerInterfa
       } else {
         const error = response.value as ErrorResponse;
         this.showErrorModal({
-          message: `Error setting up donation: ${error.message}, ${error.errors}`,
+          message: `Error setting up donation: ${error.message}`,
         });
         return response;
       }
@@ -283,7 +283,7 @@ export class DonationFlowModalManager implements DonationFlowModalManagerInterfa
       } else {
         const error = response.value as ErrorResponse;
         this.showErrorModal({
-          message: `Error setting up monthly donation: ${error.message}, ${error.errors}`,
+          message: `Error setting up monthly donation: ${error.message}`,
         });
       }
 

--- a/src/payment-flow-handlers/donation-flow-modal-manager.ts
+++ b/src/payment-flow-handlers/donation-flow-modal-manager.ts
@@ -10,6 +10,7 @@ import { PaymentProvider } from '../models/common/payment-provider-name';
 import { BillingInfo } from '../models/common/billing-info';
 import { CustomerInfo } from '../models/common/customer-info';
 import { DonationResponse } from '../models/response-models/donation-response';
+import '../modals/error-modal-content';
 
 enum ModalHeaderColor {
   Blue = '#497fbf',
@@ -173,9 +174,7 @@ export class DonationFlowModalManager implements DonationFlowModalManagerInterfa
       config: modalConfig,
       userClosedModalCallback: options?.userClosedModalCallback,
       customModalContent: html`
-        <a href="https://help.archive.org/hc/en-us/articles/360037568971-Why-is-there-a-problem-processing-my-donation-" style="color: black">
-          Questions?
-        </a>
+        <donation-form-error-modal-content></donation-form-error-modal-content>
       `
     });
   }

--- a/src/payment-flow-handlers/donation-flow-modal-manager.ts
+++ b/src/payment-flow-handlers/donation-flow-modal-manager.ts
@@ -161,13 +161,15 @@ export class DonationFlowModalManager implements DonationFlowModalManagerInterfa
   showErrorModal(options: { message: string; userClosedModalCallback?: () => void }): void {
     const modalConfig = new ModalConfig({
       headerColor: ModalHeaderColor.Red,
-      title: html`Processing error`,
+      title: html`
+        Processing error
+      `,
       headline: html`
         There's been a problem completing your donation.
       `,
       message: html`
         ${options?.message}
-      `
+      `,
     });
 
     this.modalManager.showModal({
@@ -175,7 +177,7 @@ export class DonationFlowModalManager implements DonationFlowModalManagerInterfa
       userClosedModalCallback: options?.userClosedModalCallback,
       customModalContent: html`
         <donation-form-error-modal-content></donation-form-error-modal-content>
-      `
+      `,
     });
   }
 

--- a/src/payment-flow-handlers/donation-flow-modal-manager.ts
+++ b/src/payment-flow-handlers/donation-flow-modal-manager.ts
@@ -163,7 +163,7 @@ export class DonationFlowModalManager implements DonationFlowModalManagerInterfa
       headerColor: ModalHeaderColor.Red,
       title: html`Processing error`,
       headline: html`
-        There's been a problem processing your donation.
+        There's been a problem completing your donation.
       `,
       message: html`
         ${options?.message}
@@ -255,13 +255,13 @@ export class DonationFlowModalManager implements DonationFlowModalManagerInterfa
       } else {
         const error = response.value as ErrorResponse;
         this.showErrorModal({
-          message: `Error setting up donation: ${error.message}`,
+          message: error.message,
         });
         return response;
       }
     } catch (error) {
       this.showErrorModal({
-        message: `Error setting up donation: ${error}`,
+        message: error,
       });
       console.error('error getting a response', error);
       return undefined;
@@ -288,14 +288,14 @@ export class DonationFlowModalManager implements DonationFlowModalManagerInterfa
       } else {
         const error = response.value as ErrorResponse;
         this.showErrorModal({
-          message: `Error setting up monthly donation: ${error.message}`,
+          message: error.message,
         });
       }
 
       return response;
     } catch (error) {
       this.showErrorModal({
-        message: `Error setting up monthly donation: ${error}`,
+        message: error,
       });
       console.error('error getting a response', error);
       return undefined;

--- a/src/payment-flow-handlers/handlers/applepay-flow-handler.ts
+++ b/src/payment-flow-handlers/handlers/applepay-flow-handler.ts
@@ -89,7 +89,7 @@ export class ApplePayFlowHandler
     } else {
       const errorResponse = response.value as ErrorResponse;
       this.donationFlowModalManager.showErrorModal({
-        message: `Error setting up donation: ${errorResponse.message}, ${errorResponse.errors}`,
+        message: `Error setting up donation: ${errorResponse.message}`,
       });
     }
   }

--- a/src/payment-flow-handlers/handlers/applepay-flow-handler.ts
+++ b/src/payment-flow-handlers/handlers/applepay-flow-handler.ts
@@ -57,7 +57,7 @@ export class ApplePayFlowHandler
     } else {
       const error = response.value as ErrorResponse;
       this.donationFlowModalManager.showErrorModal({
-        message: `Error setting up monthly donation: ${error}`,
+        message: error.message,
       });
     }
   }
@@ -89,7 +89,7 @@ export class ApplePayFlowHandler
     } else {
       const errorResponse = response.value as ErrorResponse;
       this.donationFlowModalManager.showErrorModal({
-        message: `Error setting up donation: ${errorResponse.message}`,
+        message: errorResponse.message,
       });
     }
   }

--- a/src/payment-flow-handlers/handlers/creditcard-flow-handler.ts
+++ b/src/payment-flow-handlers/handlers/creditcard-flow-handler.ts
@@ -122,7 +122,7 @@ export class CreditCardFlowHandler implements CreditCardFlowHandlerInterface {
       recaptchaToken = await this.recaptchaManager.execute();
     } catch (error) {
       this.donationFlowModalManager.showErrorModal({
-        message: `Recaptcha failure: ${error}`,
+        message: `Recaptcha failure`,
       });
       return;
     }

--- a/src/payment-flow-handlers/handlers/paypal-flow-handler.ts
+++ b/src/payment-flow-handlers/handlers/paypal-flow-handler.ts
@@ -18,6 +18,7 @@ import {
   DonationFlowModalManagerInterface,
   DonationFlowModalManager,
 } from '../donation-flow-modal-manager';
+import { ErrorResponse } from '../../models/response-models/error-models/error-response';
 
 export interface PayPalFlowHandlerInterface {
   updateDonationInfo(donationInfo: DonationPaymentInfo): void;
@@ -153,8 +154,9 @@ export class PayPalFlowHandler
     });
 
     if (!response.success) {
+      const error = response.value as ErrorResponse;
       this.donationFlowModalManager.showErrorModal({
-        message: 'Error setting up donation',
+        message: error.message,
       });
       return;
     }

--- a/src/payment-flow-handlers/handlers/paypal-flow-handler.ts
+++ b/src/payment-flow-handlers/handlers/paypal-flow-handler.ts
@@ -299,8 +299,6 @@ export class PayPalFlowHandler
         oneTimeSuccessResponse: options.oneTimeSuccessResponse,
       });
     } else {
-      // this.showErrorModal();
-      // alert('ERROR RENDERING UPSELL PAYPAL BUTTON');
       console.error('error rendering paypal upsell button');
     }
   }

--- a/src/payment-flow-handlers/handlers/venmo-flow-handler.ts
+++ b/src/payment-flow-handlers/handlers/venmo-flow-handler.ts
@@ -81,7 +81,7 @@ export class VenmoFlowHandler implements VenmoFlowHandlerInterface {
       this.restorationStateHandler.clearState();
       this.handleTokenizationError(tokenizeError);
       this.donationFlowModalManager.showErrorModal({
-        message: `Error loading donation information: ${tokenizeError}`,
+        message: `Error loading donation information`,
       });
     }
   }

--- a/src/payment-flow-handlers/handlers/venmo-flow-handler.ts
+++ b/src/payment-flow-handlers/handlers/venmo-flow-handler.ts
@@ -81,7 +81,7 @@ export class VenmoFlowHandler implements VenmoFlowHandlerInterface {
       this.restorationStateHandler.clearState();
       this.handleTokenizationError(tokenizeError);
       this.donationFlowModalManager.showErrorModal({
-        message: `Error loading donation information`,
+        message: `There was a problem loading your donation information. Please try again.`,
       });
     }
   }

--- a/test/tests/flow-handlers/donation-flow-modal-manager.test.ts
+++ b/test/tests/flow-handlers/donation-flow-modal-manager.test.ts
@@ -76,7 +76,9 @@ describe('Donation Flow Modal Manager', () => {
     expect(modalOptions?.config.showProcessingIndicator).to.be.false;
     expect(modalOptions?.config.closeOnBackdropClick).to.be.true;
     expect(modalOptions?.config.showCloseButton).to.be.true;
-    expect(modalOptions?.config.headline?.getHTML().trim()).to.equal('An Error Occurred');
+    expect(modalOptions?.config.headline?.getHTML().trim()).to.equal(
+      "There's been a problem completing your donation.",
+    );
     expect(modalOptions?.config.message?.values[0]).to.equal('foo-error');
   });
 


### PR DESCRIPTION
This updates the error messaging and error modal to be more useful.

Previously we were displaying an error message that looked like `An error occurred: ,` because we weren't getting the proper error messaging from Braintree. This adds a "Questions?" link at the bottom of the error modal and makes the text more friendly.

<img width="424" alt="Screen Shot 2020-08-25 at 1 04 12 PM" src="https://user-images.githubusercontent.com/51138/91222055-7e51cf00-e6d3-11ea-8a73-8842512e63b3.png">
