### PR TITLE
Add support for `origin` custom field

### DIFF
--- a/packages/data-models/package-lock.json
+++ b/packages/data-models/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/donation-form-data-models",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/data-models/package-lock.json
+++ b/packages/data-models/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/donation-form-data-models",
-  "version": "0.3.0",
+  "version": "0.3.1-alpha.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/data-models/package-lock.json
+++ b/packages/data-models/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/donation-form-data-models",
-  "version": "0.3.1-alpha.1",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/data-models/package.json
+++ b/packages/data-models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/donation-form-data-models",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Internet Archive Donation Form Data Models",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",

--- a/packages/data-models/package.json
+++ b/packages/data-models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/donation-form-data-models",
-  "version": "0.3.0",
+  "version": "0.3.1-alpha.1",
   "description": "Internet Archive Donation Form Data Models",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",

--- a/packages/data-models/package.json
+++ b/packages/data-models/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/donation-form-data-models",
-  "version": "0.3.1-alpha.1",
+  "version": "0.3.0",
   "description": "Internet Archive Donation Form Data Models",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",

--- a/packages/data-models/src/request-models/donation-request-custom-fields.ts
+++ b/packages/data-models/src/request-models/donation-request-custom-fields.ts
@@ -7,13 +7,16 @@ export class DonationRequestCustomFields {
   /**
    * The origin is made up of campaign / ABTest information that the user originated from.
    *
-   * The field is a string so can be expanded on,
-   * but generally has the format `{Source}-{Test Name}-{Variant Name}`, ie
+   * The field is a freeform string so it can be anything, but make sure it's something
+   * identifiable so it can be queried in CiviCRM.
+   *
+   * For instance, we use this format for the Donation Banner:
+   * - `{Source}-{Test Name}-{Variant Name}`, eg:
    * - `DonateBanner-Campaign Start 2020-IADefault`
-   * - `Email-MidJuly2020-VariantA`
+   * - `DonateBanner-Mid Campaign-IAThermometer`
    *
    * For additional specificity, you could add additional info, ie.
-   * `Email-MidJuly2020-VariantA-Button1`
+   * - `DonateBanner-MidJuly2020 Campaign-VariantA-Button1`
    *
    * @type {string}
    * @memberof DonationRequestCustomFields

--- a/packages/data-models/src/request-models/donation-request-custom-fields.ts
+++ b/packages/data-models/src/request-models/donation-request-custom-fields.ts
@@ -4,15 +4,33 @@ export class DonationRequestCustomFields {
   referrer?: string;
   fee_amount_covered?: number;
 
+  /**
+   * The origin is made up of campaign / ABTest information that the user originated from.
+   *
+   * The field is a string so can be expanded on,
+   * but generally has the format `{Source}-{Test Name}-{Variant Name}`, ie
+   * - `DonateBanner-Campaign Start 2020-IADefault`
+   * - `Email-MidJuly2020-VariantA`
+   *
+   * For additional specificity, you could add additional info, ie.
+   * `Email-MidJuly2020-VariantA-Button1`
+   *
+   * @type {string}
+   * @memberof DonationRequestCustomFields
+   */
+  origin?: string;
+
   constructor(options?: {
     logged_in_user?: string;
     referrer?: string;
     fee_amount_covered?: number;
+    origin?: string;
   }) {
     // eslint-disable-next-line @typescript-eslint/camelcase
     this.logged_in_user = options?.logged_in_user;
     this.referrer = options?.referrer;
     // eslint-disable-next-line @typescript-eslint/camelcase
     this.fee_amount_covered = options?.fee_amount_covered;
+    this.origin = options?.origin;
   }
 }

--- a/packages/donation-form/package-lock.json
+++ b/packages/donation-form/package-lock.json
@@ -3112,9 +3112,9 @@
       "integrity": "sha512-IsIuy9dXpZmDEeQpgpdxqUTQ6URCWkx0W2qMoaFtOFqKJSnE5/+19NCoP7Il4xGqA2wm/Px9RLwMCGwTpuXPRA=="
     },
     "@internetarchive/donation-form-data-models": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@internetarchive/donation-form-data-models/-/donation-form-data-models-0.3.0.tgz",
-      "integrity": "sha512-eU3N5NtB9EMt5+fd2M7Kj3EeELAoikNf24iMW0ggdcWmstWQ9rmDAxOaj4pRCC87qlWhDZ/j5V4GqIvyzQVyWg=="
+      "version": "0.3.1-alpha.1",
+      "resolved": "https://registry.npmjs.org/@internetarchive/donation-form-data-models/-/donation-form-data-models-0.3.1-alpha.1.tgz",
+      "integrity": "sha512-bsPBzyy79bM+YDoifnZdBMSdo/R4LkSReA89L07OCHby4xXFKy75/PabT6GN1UhY/YR0M5MQeL75dmfxS7Egdw=="
     },
     "@internetarchive/donation-form-edit-donation": {
       "version": "0.3.1",
@@ -3129,6 +3129,11 @@
         "lit-html": "^1.1.2"
       },
       "dependencies": {
+        "@internetarchive/donation-form-data-models": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/@internetarchive/donation-form-data-models/-/donation-form-data-models-0.3.0.tgz",
+          "integrity": "sha512-eU3N5NtB9EMt5+fd2M7Kj3EeELAoikNf24iMW0ggdcWmstWQ9rmDAxOaj4pRCC87qlWhDZ/j5V4GqIvyzQVyWg=="
+        },
         "currency.js": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/currency.js/-/currency.js-2.0.3.tgz",

--- a/packages/donation-form/package-lock.json
+++ b/packages/donation-form/package-lock.json
@@ -3112,9 +3112,9 @@
       "integrity": "sha512-IsIuy9dXpZmDEeQpgpdxqUTQ6URCWkx0W2qMoaFtOFqKJSnE5/+19NCoP7Il4xGqA2wm/Px9RLwMCGwTpuXPRA=="
     },
     "@internetarchive/donation-form-data-models": {
-      "version": "0.3.1-alpha.1",
-      "resolved": "https://registry.npmjs.org/@internetarchive/donation-form-data-models/-/donation-form-data-models-0.3.1-alpha.1.tgz",
-      "integrity": "sha512-bsPBzyy79bM+YDoifnZdBMSdo/R4LkSReA89L07OCHby4xXFKy75/PabT6GN1UhY/YR0M5MQeL75dmfxS7Egdw=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@internetarchive/donation-form-data-models/-/donation-form-data-models-0.3.1.tgz",
+      "integrity": "sha512-j0bhVH1GnOjwFlLRsY0jkvMVgfNw1IQW51eYkZNqoxR+jwvSNMy7qAonCTNYlAYlaw1qPNhq660cecohHUU5Hg=="
     },
     "@internetarchive/donation-form-edit-donation": {
       "version": "0.3.1",
@@ -3129,11 +3129,6 @@
         "lit-html": "^1.1.2"
       },
       "dependencies": {
-        "@internetarchive/donation-form-data-models": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/@internetarchive/donation-form-data-models/-/donation-form-data-models-0.3.0.tgz",
-          "integrity": "sha512-eU3N5NtB9EMt5+fd2M7Kj3EeELAoikNf24iMW0ggdcWmstWQ9rmDAxOaj4pRCC87qlWhDZ/j5V4GqIvyzQVyWg=="
-        },
         "currency.js": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/currency.js/-/currency.js-2.0.3.tgz",

--- a/packages/donation-form/package.json
+++ b/packages/donation-form/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@internetarchive/donation-form-currency-validator": "^0.3.0",
-    "@internetarchive/donation-form-data-models": "^0.3.1-alpha.1",
+    "@internetarchive/donation-form-data-models": "^0.3.1",
     "@internetarchive/donation-form-edit-donation": "^0.3.1",
     "@internetarchive/donation-form-section": "^0.3.0",
     "@internetarchive/icon-applepay": "^0.4.0",

--- a/packages/donation-form/package.json
+++ b/packages/donation-form/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@internetarchive/donation-form-currency-validator": "^0.3.0",
-    "@internetarchive/donation-form-data-models": "^0.3.0",
+    "@internetarchive/donation-form-data-models": "^0.3.1-alpha.1",
     "@internetarchive/donation-form-edit-donation": "^0.3.1",
     "@internetarchive/donation-form-section": "^0.3.0",
     "@internetarchive/icon-applepay": "^0.4.0",

--- a/packages/donation-form/src/braintree-manager/braintree-interfaces.ts
+++ b/packages/donation-form/src/braintree-manager/braintree-interfaces.ts
@@ -50,6 +50,14 @@ export interface BraintreeManagerInterface {
   setReferrer(referrer: string): void;
 
   /**
+   * Set the origin for later submission
+   *
+   * @param {string} origin
+   * @memberof BraintreeManagerInterface
+   */
+  setOrigin(origin: string): void;
+
+  /**
    * Set the logged-in user for later submission
    *
    * @param {string} loggedInUser

--- a/packages/donation-form/src/braintree-manager/braintree-manager.ts
+++ b/packages/donation-form/src/braintree-manager/braintree-manager.ts
@@ -26,11 +26,18 @@ export class BraintreeManager implements BraintreeManagerInterface {
   private referrer?: string;
 
   /**
-   * The origin is made up of campaign / abtest information that the user originated from.
+   * The origin is made up of campaign / ABTest information that the user originated from.
    *
-   * The field is a string, but generally has the format `{Source}-{Test Name}-{Variant Name}`, ie
+   * The field is a freeform string so it can be anything, but make sure it's something
+   * identifiable so it can be queried in CiviCRM.
+   *
+   * For instance, we use this format for the Donation Banner:
+   * - `{Source}-{Test Name}-{Variant Name}`, eg:
    * - `DonateBanner-Campaign Start 2020-IADefault`
-   * - `Email-MidJuly2020-VariantA`
+   * - `DonateBanner-Mid Campaign-IAThermometer`
+   *
+   * For additional specificity, you could add additional info, ie.
+   * - `DonateBanner-MidJuly2020 Campaign-VariantA-Button1`
    *
    * @private
    * @type {string}

--- a/packages/donation-form/src/braintree-manager/braintree-manager.ts
+++ b/packages/donation-form/src/braintree-manager/braintree-manager.ts
@@ -25,6 +25,19 @@ import { PaymentProvidersInterface } from './payment-providers-interface';
 export class BraintreeManager implements BraintreeManagerInterface {
   private referrer?: string;
 
+  /**
+   * The origin is made up of campaign / abtest information that the user originated from.
+   *
+   * The field is a string, but generally has the format `{Source}-{Test Name}-{Variant Name}`, ie
+   * - `DonateBanner-Campaign Start 2020-IADefault`
+   * - `Email-MidJuly2020-VariantA`
+   *
+   * @private
+   * @type {string}
+   * @memberof BraintreeManager
+   */
+  private origin?: string;
+
   private loggedInUser?: string;
 
   /**
@@ -68,6 +81,7 @@ export class BraintreeManager implements BraintreeManagerInterface {
     // eslint-disable-next-line @typescript-eslint/camelcase
     customFields.logged_in_user = this.loggedInUser;
     customFields.referrer = this.referrer;
+    customFields.origin = this.origin;
 
     // This is interesting and applies only to Venmo, but will work for other providers as well.
     // In Safari, `donationInfo` actually comes through as a DonationPaymentInfo object,
@@ -200,6 +214,7 @@ export class BraintreeManager implements BraintreeManagerInterface {
     googlePayMerchantId?: string;
     referrer?: string;
     loggedInUser?: string;
+    origin?: string;
   }) {
     this.authorizationToken = options.authorizationToken;
     this.endpointManager = options.endpointManager;
@@ -208,6 +223,7 @@ export class BraintreeManager implements BraintreeManagerInterface {
 
     this.referrer = options.referrer;
     this.loggedInUser = options.loggedInUser;
+    this.origin = options.origin;
 
     this.paymentProviders = new PaymentProviders({
       braintreeManager: this,
@@ -233,5 +249,10 @@ export class BraintreeManager implements BraintreeManagerInterface {
   /** @inheritdoc */
   setLoggedInUser(loggedInUser: string): void {
     this.loggedInUser = loggedInUser;
+  }
+
+  /** @inheritdoc */
+  setOrigin(origin: string): void {
+    this.origin = origin;
   }
 }

--- a/packages/donation-form/src/donation-form-controller.ts
+++ b/packages/donation-form/src/donation-form-controller.ts
@@ -74,6 +74,8 @@ export class DonationFormController extends LitElement {
 
   @property({ type: String }) loggedInUser?: string;
 
+  @property({ type: String }) origin?: string;
+
   @property({ type: Object }) endpointManager?: BraintreeEndpointManagerInterface;
 
   @property({ type: Object }) analyticsHandler?: AnalyticsHandlerInterface;
@@ -110,6 +112,10 @@ export class DonationFormController extends LitElement {
 
     if (changedProperties.has('loggedInUser') && this.loggedInUser) {
       this.braintreeManager?.setLoggedInUser(this.loggedInUser);
+    }
+
+    if (changedProperties.has('origin') && this.origin) {
+      this.braintreeManager?.setOrigin(this.origin);
     }
 
     if (
@@ -158,6 +164,7 @@ export class DonationFormController extends LitElement {
         hostingEnvironment: this.environment,
         referrer: this.referrer,
         loggedInUser: this.loggedInUser,
+        origin: this.origin,
       });
     }
   }

--- a/packages/donation-form/test/mocks/mock-braintree-manager.ts
+++ b/packages/donation-form/test/mocks/mock-braintree-manager.ts
@@ -45,6 +45,8 @@ export class MockBraintreeManager implements BraintreeManagerInterface {
 
   setLoggedInUser(loggedInUser: string): void {}
 
+  setOrigin(origin: string): void {}
+
   startup(): void {}
 
   async submitDonation(options: {

--- a/packages/donation-form/test/tests/braintree-manager.test.ts
+++ b/packages/donation-form/test/tests/braintree-manager.test.ts
@@ -80,7 +80,7 @@ describe('Braintree Manager', () => {
     expect(endpointManager.requestSubmitted?.deviceData).to.equal(undefined);
   });
 
-  it('can properly set referrer and logged in user and submits them to the endpoint', async () => {
+  it('can properly set referrer, origin, and logged in user and submits them to the endpoint', async () => {
     const paymentClients = new MockPaymentClients();
     const endpointManager = new MockEndpointManager();
 
@@ -106,6 +106,7 @@ describe('Braintree Manager', () => {
 
     braintreeManager.setLoggedInUser('foo-user');
     braintreeManager.setReferrer('foo-referrer');
+    braintreeManager.setOrigin('foo-origin');
 
     await braintreeManager.submitDonation({
       nonce: 'boop',
@@ -117,6 +118,35 @@ describe('Braintree Manager', () => {
 
     expect(endpointManager.requestSubmitted?.customFields.referrer).to.equal('foo-referrer');
     expect(endpointManager.requestSubmitted?.customFields.logged_in_user).to.equal('foo-user');
+    expect(endpointManager.requestSubmitted?.customFields.origin).to.equal('foo-origin');
+  });
+
+  it('can be initialized with referrer, origin, and logged in user and submits them to the endpoint', async () => {
+    const paymentClients = new MockPaymentClients();
+    const endpointManager = new MockEndpointManager();
+
+    const braintreeManager = new BraintreeManager({
+      authorizationToken: 'foo',
+      paymentClients,
+      endpointManager,
+      hostedFieldConfig: mockHostedFieldConfig,
+      hostingEnvironment: HostingEnvironment.Development,
+      loggedInUser: 'foo-user',
+      referrer: 'foo-referrer',
+      origin: 'foo-origin',
+    });
+
+    await braintreeManager.submitDonation({
+      nonce: 'boop',
+      paymentProvider: PaymentProvider.CreditCard,
+      donationInfo: new MockDonationInfo(),
+      billingInfo: mockBillingInfo,
+      customerInfo: mockCustomerInfo,
+    });
+
+    expect(endpointManager.requestSubmitted?.customFields.referrer).to.equal('foo-referrer');
+    expect(endpointManager.requestSubmitted?.customFields.logged_in_user).to.equal('foo-user');
+    expect(endpointManager.requestSubmitted?.customFields.origin).to.equal('foo-origin');
   });
 
   it('properly submits an upsell donation', async () => {


### PR DESCRIPTION
This adds support for the `origin` custom field. The origin custom field is used to track the original source of the patron, ie `DonateBanner-ABTest1-VariantA` or `Email-July2020-ButtonA`. It's freeform so whatever makes sense to the consumer.