### PR TITLE
Add support for condensed selection mode layout

### DIFF
--- a/packages/donation-form/package.json
+++ b/packages/donation-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/donation-form",
-  "version": "0.5.2",
+  "version": "0.5.3-alpha.1",
   "description": "The Internet Archive Donation Form",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",

--- a/packages/donation-form/package.json
+++ b/packages/donation-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/donation-form",
-  "version": "0.5.3-alpha.2",
+  "version": "0.5.3",
   "description": "The Internet Archive Donation Form",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",
@@ -30,7 +30,7 @@
   "dependencies": {
     "@internetarchive/donation-form-currency-validator": "^0.3.0",
     "@internetarchive/donation-form-data-models": "^0.3.2",
-    "@internetarchive/donation-form-edit-donation": "0.3.7-alpha.2",
+    "@internetarchive/donation-form-edit-donation": "^0.3.7",
     "@internetarchive/donation-form-section": "^0.3.1",
     "@internetarchive/icon-applepay": "^0.4.0",
     "@internetarchive/icon-calendar": "^0.4.0",

--- a/packages/donation-form/package.json
+++ b/packages/donation-form/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@internetarchive/donation-form-currency-validator": "^0.3.0",
     "@internetarchive/donation-form-data-models": "^0.3.2",
-    "@internetarchive/donation-form-edit-donation": "^0.3.6",
+    "@internetarchive/donation-form-edit-donation": "0.3.7-alpha.2",
     "@internetarchive/donation-form-section": "^0.3.1",
     "@internetarchive/icon-applepay": "^0.4.0",
     "@internetarchive/icon-calendar": "^0.4.0",

--- a/packages/donation-form/package.json
+++ b/packages/donation-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/donation-form",
-  "version": "0.5.3-alpha.1",
+  "version": "0.5.3-alpha.2",
   "description": "The Internet Archive Donation Form",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",

--- a/packages/donation-form/src/donation-form-controller.ts
+++ b/packages/donation-form/src/donation-form-controller.ts
@@ -43,6 +43,7 @@ import creditCardImg from '@internetarchive/icon-credit-card';
 import calendarImg from '@internetarchive/icon-calendar';
 import lockImg from '@internetarchive/icon-lock';
 import { AnalyticsHandlerInterface } from './@types/analytics-handler';
+import { EditDonationAmountSelectionLayout, EditDonationFrequencySelectionMode } from '@internetarchive/donation-form-edit-donation';
 
 import {
   DonationPaymentInfo,
@@ -78,6 +79,10 @@ export class DonationFormController extends LitElement {
   @property({ type: Array }) amountOptions: number[] = defaultDonationAmounts;
 
   @property({ type: Object }) donationInfo: DonationPaymentInfo = defaultSelectedDonationInfo;
+
+  @property({ type: String }) amountSelectionLayout: EditDonationAmountSelectionLayout = EditDonationAmountSelectionLayout.MultiLine;
+
+  @property({ type: String }) frequencySelectionMode: EditDonationFrequencySelectionMode = EditDonationFrequencySelectionMode.Button;
 
   @property({ type: String }) referrer?: string;
 
@@ -247,6 +252,16 @@ export class DonationFormController extends LitElement {
       }
     }
 
+    const amountLayout = urlParams.get('amountLayout') as EditDonationAmountSelectionLayout;
+    if (amountLayout) {
+      this.amountSelectionLayout = amountLayout;
+    }
+
+    const frequencyMode = urlParams.get('frequencyMode') as EditDonationFrequencySelectionMode;
+    if (frequencyMode) {
+      this.frequencySelectionMode = frequencyMode;
+    }
+
     const donationInfo = new DonationPaymentInfo({
       donationType: frequency,
       amount: amount,
@@ -345,6 +360,8 @@ export class DonationFormController extends LitElement {
           .contactForm=${this.contactForm}
           .amountOptions=${this.amountOptions}
           .donationInfo=${this.donationInfo}
+          .amountSelectionLayout=${this.amountSelectionLayout}
+          .frequencySelectionMode=${this.frequencySelectionMode}
           @donationInfoChanged=${this.donationInfoChanged}
           @paymentProviderSelected=${this.paymentProviderSelected}
           @paymentFlowStarted=${this.paymentFlowStarted}

--- a/packages/donation-form/src/donation-form-controller.ts
+++ b/packages/donation-form/src/donation-form-controller.ts
@@ -252,14 +252,20 @@ export class DonationFormController extends LitElement {
       }
     }
 
-    const amountLayout = urlParams.get('amountLayout') as EditDonationAmountSelectionLayout;
-    if (amountLayout) {
-      this.amountSelectionLayout = amountLayout;
+    const amountLayoutParam = urlParams.get('amountLayout');
+    if (amountLayoutParam) {
+      const amountLayout = amountLayoutParam as EditDonationAmountSelectionLayout;
+      if (Object.values(EditDonationAmountSelectionLayout).includes(amountLayout)) {
+        this.amountSelectionLayout = amountLayout;
+      }
     }
 
-    const frequencyMode = urlParams.get('frequencyMode') as EditDonationFrequencySelectionMode;
-    if (frequencyMode) {
-      this.frequencySelectionMode = frequencyMode;
+    const frequencyModeParam = urlParams.get('frequencyMode');
+    if (frequencyModeParam) {
+      const frequencyMode = frequencyModeParam as EditDonationFrequencySelectionMode;
+      if (Object.values(EditDonationFrequencySelectionMode).includes(frequencyMode)) {
+        this.frequencySelectionMode = frequencyMode;
+      }
     }
 
     const donationInfo = new DonationPaymentInfo({

--- a/packages/donation-form/src/donation-form.ts
+++ b/packages/donation-form/src/donation-form.ts
@@ -100,7 +100,7 @@ export class DonationForm extends LitElement {
         </donation-form-total-amount>
       </donation-form-section>
 
-      <donation-form-section .sectionBadge=${this.formSectionNumberingStart} headline="Choose a payment method">
+      <donation-form-section .sectionBadge=${this.paymentSelectorNumberingStart} headline="Choose a payment method">
         <payment-selector
           .paymentProviders=${this.braintreeManager?.paymentProviders}
           @firstUpdated=${this.paymentSelectorFirstUpdated}
@@ -172,7 +172,7 @@ export class DonationForm extends LitElement {
   get contactFormSectionTemplate(): TemplateResult {
     return html`
       <donation-form-section
-        .sectionBadge=${this.formSectionNumberingStart + 1}
+        .sectionBadge=${this.paymentSelectorNumberingStart + 1}
         headline="Enter payment information"
         id="contactFormSection"
       >
@@ -182,7 +182,7 @@ export class DonationForm extends LitElement {
         </div>
       </donation-form-section>
 
-      <donation-form-section .sectionBadge=${this.formSectionNumberingStart + 2}>
+      <donation-form-section .sectionBadge=${this.paymentSelectorNumberingStart + 2}>
         <slot name="recaptcha"></slot>
         <button id="donate-button" @click=${this.donateClicked}>
           Donate
@@ -195,9 +195,35 @@ export class DonationForm extends LitElement {
     `;
   }
 
-  private get formSectionNumberingStart(): number {
-    // In "Button" mode, the frequency selector is section 1,
-    // but in "Checkbox" mode, it's just a small checkbox below the amount selector
+  /**
+   * Where to start the numbering of the payment selector
+   *
+   * - If we show the frequency selector in button mode, it becomes section 1, which makes
+   * the amount selection section 2, and the payment selector section 3.
+   * - If we show the frequency selector in checkbox mode, it is no longer section 1. The amount
+   * selector becomes section 1 and the payment selector becomes section 2.
+   *
+   * Visually:
+   *
+   * Button Mode:
+   * 1. Frequency selector
+   * 2. Amount selector
+   * 3. Payment selector
+   * 4. Contact info
+   * 5. Donate button
+   *
+   * Checkbox Mode:
+   * 1. Amount selector (including the monthly checkbox)
+   * 2. Payment selector <-- changes from 3 to 2
+   * 3. Contact info <-- changes from 4 to 3
+   * 4. Donate button <-- changes from 5 to 4
+   *
+   * @readonly
+   * @private
+   * @type {number}
+   * @memberof DonationForm
+   */
+  private get paymentSelectorNumberingStart(): number {
     return this.frequencySelectionMode === EditDonationFrequencySelectionMode.Button ? 3 : 2;
   }
 

--- a/packages/donation-form/src/donation-form.ts
+++ b/packages/donation-form/src/donation-form.ts
@@ -35,6 +35,8 @@ import {
 
 import { PaymentFlowHandlersInterface } from './payment-flow-handlers/payment-flow-handlers';
 
+import { EditDonationAmountSelectionLayout, EditDonationFrequencySelectionMode } from '@internetarchive/donation-form-edit-donation';
+
 import '@internetarchive/donation-form-section';
 import {
   DonationFormSection,
@@ -58,6 +60,10 @@ export class DonationForm extends LitElement {
 
   @property({ type: Array }) amountOptions: number[] = defaultDonationAmounts;
 
+  @property({ type: String }) amountSelectionLayout: EditDonationAmountSelectionLayout = EditDonationAmountSelectionLayout.MultiLine;
+
+  @property({ type: String }) frequencySelectionMode: EditDonationFrequencySelectionMode = EditDonationFrequencySelectionMode.Button;
+
   @property({ type: Boolean }) private creditCardVisible = false;
 
   @property({ type: Boolean }) private contactFormVisible = false;
@@ -79,6 +85,8 @@ export class DonationForm extends LitElement {
     return html`
       <donation-form-header
         .amountOptions=${this.amountOptions}
+        .amountSelectionLayout=${this.amountSelectionLayout}
+        .frequencySelectionMode=${this.frequencySelectionMode}
         @donationInfoChanged=${this.donationInfoChanged}
         @editDonationError=${this.editDonationError}
       >
@@ -92,7 +100,7 @@ export class DonationForm extends LitElement {
         </donation-form-total-amount>
       </donation-form-section>
 
-      <donation-form-section sectionBadge="3" headline="Choose a payment method">
+      <donation-form-section .sectionBadge=${this.formSectionNumberingStart} headline="Choose a payment method">
         <payment-selector
           .paymentProviders=${this.braintreeManager?.paymentProviders}
           @firstUpdated=${this.paymentSelectorFirstUpdated}
@@ -164,7 +172,7 @@ export class DonationForm extends LitElement {
   get contactFormSectionTemplate(): TemplateResult {
     return html`
       <donation-form-section
-        sectionBadge="4"
+        .sectionBadge=${this.formSectionNumberingStart + 1}
         headline="Enter payment information"
         id="contactFormSection"
       >
@@ -174,7 +182,7 @@ export class DonationForm extends LitElement {
         </div>
       </donation-form-section>
 
-      <donation-form-section sectionBadge="5">
+      <donation-form-section .sectionBadge=${this.formSectionNumberingStart + 2}>
         <slot name="recaptcha"></slot>
         <button id="donate-button" @click=${this.donateClicked}>
           Donate
@@ -185,6 +193,12 @@ export class DonationForm extends LitElement {
         </div>
       </donation-form-section>
     `;
+  }
+
+  private get formSectionNumberingStart(): number {
+    // In "Button" mode, the frequency selector is section 1,
+    // but in "Checkbox" mode, it's just a small checkbox below the amount selector
+    return this.frequencySelectionMode === EditDonationFrequencySelectionMode.Button ? 3 : 2;
   }
 
   private editDonationError(): void {

--- a/packages/donation-form/src/form-elements/header/donation-form-header.ts
+++ b/packages/donation-form/src/form-elements/header/donation-form-header.ts
@@ -15,7 +15,7 @@ import {
 } from '@internetarchive/donation-form-data-models';
 
 import '@internetarchive/donation-form-edit-donation';
-import { DonationFormEditDonation } from '@internetarchive/donation-form-edit-donation';
+import { DonationFormEditDonation, EditDonationAmountSelectionLayout, EditDonationFrequencySelectionMode } from '@internetarchive/donation-form-edit-donation';
 
 export enum DonationFormHeaderMode {
   Summary = 'summary',
@@ -29,6 +29,10 @@ export class DonationFormHeader extends LitElement {
   @property({ type: String }) mode: DonationFormHeaderMode = DonationFormHeaderMode.Edit;
 
   @property({ type: Array }) amountOptions: number[] = defaultDonationAmounts;
+
+  @property({ type: String }) amountSelectionLayout: EditDonationAmountSelectionLayout = EditDonationAmountSelectionLayout.MultiLine;
+
+  @property({ type: String }) frequencySelectionMode: EditDonationFrequencySelectionMode = EditDonationFrequencySelectionMode.Button;
 
   @query('edit-donation') editDonation?: DonationFormEditDonation;
 
@@ -53,6 +57,8 @@ export class DonationFormHeader extends LitElement {
       <donation-form-edit-donation
         .donationInfo=${this.donationInfo}
         .amountOptions=${this.amountOptions}
+        .amountSelectionLayout=${this.amountSelectionLayout}
+        .frequencySelectionMode=${this.frequencySelectionMode}
         @donationInfoChanged=${this.donationInfoChanged}
         @showSummaryClicked=${this.showSummaryClicked}
         @editDonationError=${this.editDonationError}

--- a/packages/donation-form/yarn.lock
+++ b/packages/donation-form/yarn.lock
@@ -854,10 +854,10 @@
   resolved "https://registry.yarnpkg.com/@internetarchive/donation-form-data-models/-/donation-form-data-models-0.3.2.tgz#5f3e47238918b8c9a7f0a5cf44c5630c1b570bed"
   integrity sha512-yxjwwr/2YMIx56IN9ZVETqByc7jlsX6s57zk1K+bWgA0u+D0OKScWKX+dLxaz2viRNSQOEOR1MsQWwaKshh0Tg==
 
-"@internetarchive/donation-form-edit-donation@^0.3.6":
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/@internetarchive/donation-form-edit-donation/-/donation-form-edit-donation-0.3.6.tgz#f1a9c046abc19465f410bd74bacf7e160fac02d7"
-  integrity sha512-wM9sHVAEda+NVAzWgat/5BIMq2Oe4tJ0v2TWgOBp8/R/OP1nyPXl9kwTgxH04hCS51WISu3y6wUAQlYYTKp88g==
+"@internetarchive/donation-form-edit-donation@0.3.7-alpha.2":
+  version "0.3.7-alpha.2"
+  resolved "https://registry.yarnpkg.com/@internetarchive/donation-form-edit-donation/-/donation-form-edit-donation-0.3.7-alpha.2.tgz#1046b1a821b8fe094b84d6345f60683166809ff2"
+  integrity sha512-hQRG51wCdc7YbINSHusio+caPkq3h5SuIHpxDPbR7LcG/0AB2G/QPawXPGr3A+keEVkFOJTE0J8F7o7O4CJlVA==
   dependencies:
     "@internetarchive/donation-form-currency-validator" "^0.3.0"
     "@internetarchive/donation-form-data-models" "^0.3.2"

--- a/packages/donation-form/yarn.lock
+++ b/packages/donation-form/yarn.lock
@@ -854,10 +854,10 @@
   resolved "https://registry.yarnpkg.com/@internetarchive/donation-form-data-models/-/donation-form-data-models-0.3.2.tgz#5f3e47238918b8c9a7f0a5cf44c5630c1b570bed"
   integrity sha512-yxjwwr/2YMIx56IN9ZVETqByc7jlsX6s57zk1K+bWgA0u+D0OKScWKX+dLxaz2viRNSQOEOR1MsQWwaKshh0Tg==
 
-"@internetarchive/donation-form-edit-donation@0.3.7-alpha.2":
-  version "0.3.7-alpha.2"
-  resolved "https://registry.yarnpkg.com/@internetarchive/donation-form-edit-donation/-/donation-form-edit-donation-0.3.7-alpha.2.tgz#1046b1a821b8fe094b84d6345f60683166809ff2"
-  integrity sha512-hQRG51wCdc7YbINSHusio+caPkq3h5SuIHpxDPbR7LcG/0AB2G/QPawXPGr3A+keEVkFOJTE0J8F7o7O4CJlVA==
+"@internetarchive/donation-form-edit-donation@^0.3.7":
+  version "0.3.7"
+  resolved "https://registry.yarnpkg.com/@internetarchive/donation-form-edit-donation/-/donation-form-edit-donation-0.3.7.tgz#d47c3b35fef355617d35e7bb1b9f2b92136197f6"
+  integrity sha512-A++t9rza6SVdudjZ9PfRhM2kD71y6fml5p9YKKfqqtSdU/3+qvOfEKKhYDi0OiYpqaFIbaPmk27fOrXyfV8RvA==
   dependencies:
     "@internetarchive/donation-form-currency-validator" "^0.3.0"
     "@internetarchive/donation-form-data-models" "^0.3.2"

--- a/packages/edit-donation/demo/app-root.ts
+++ b/packages/edit-donation/demo/app-root.ts
@@ -15,6 +15,8 @@ import {
 import {
   DonationFormEditDonation,
   DonationFormEditDonationStepNumberMode,
+  EditDonationFrequencySelectionMode,
+  EditDonationAmountSelectionLayout,
 } from '../src/donation-form-edit-donation';
 
 @customElement('app-root')
@@ -36,6 +38,12 @@ export class AppRoot extends LitElement {
 
   @query('input[name=donationType]:checked')
   private selectedDonationType!: HTMLInputElement;
+
+  @query('input[name=amounts-layout]:checked')
+  private amountsLayoutOption!: HTMLInputElement;
+
+  @query('input[name=frequency-option]:checked')
+  private frequencySelectionOption!: HTMLInputElement;
 
   @query('#amount-input') private amountInput!: HTMLInputElement;
 
@@ -107,6 +115,51 @@ export class AppRoot extends LitElement {
           </ul>
         </fieldset>
 
+        <fieldset>
+          <legend>Layout</legend>
+          <ul>
+            <li>
+              Amounts Layout:
+              <input
+                type="radio"
+                name="amounts-layout"
+                id="amount-single-line"
+                value="single-line"
+              />
+              <label for="amount-single-line">Single Line</label>
+              <input
+                type="radio"
+                name="amounts-layout"
+                id="amount-multi-line"
+                value="multi-line"
+                checked
+              />
+              <label for="amount-multi-line">Multi Line</label>
+            </li>
+            <li>
+              Frequency Option:
+              <input
+                type="radio"
+                name="frequency-option"
+                id="frequency-layout-buttons"
+                value="button"
+                checked
+              />
+              <label for="frequency-layout-buttons">Buttons</label>
+              <input
+                type="radio"
+                name="frequency-option"
+                id="frequency-layout-checkbox"
+                value="checkbox"
+              />
+              <label for="frequency-layout-checkbox">Checkbox</label>
+            </li>
+            <li>
+              <button @click=${this.updateLayout}>Update</button>
+            </li>
+          </ul>
+        </fieldset>
+
         <div id="error"></div>
       </div>
     `;
@@ -135,6 +188,13 @@ export class AppRoot extends LitElement {
   private editDonationError(e: CustomEvent): void {
     this.errorDiv.innerText = e.detail.error;
     this.totalDiv.innerText = 'Invalid';
+  }
+
+  private updateLayout(): void {
+    this.editDonation.frequencySelectionMode = this.frequencySelectionOption
+      .value as EditDonationFrequencySelectionMode;
+    this.editDonation.amountSelectionLayout = this.amountsLayoutOption
+      .value as EditDonationAmountSelectionLayout;
   }
 
   private updateForm(): void {

--- a/packages/edit-donation/index.ts
+++ b/packages/edit-donation/index.ts
@@ -3,4 +3,6 @@ export {
   DonationFormEditDonationStepNumberMode,
   EditDonationInfoStatus,
   EditDonationSelectionGroup,
+  EditDonationFrequencySelectionMode,
+  EditDonationAmountSelectionLayout,
 } from './src/donation-form-edit-donation';

--- a/packages/edit-donation/package.json
+++ b/packages/edit-donation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/donation-form-edit-donation",
-  "version": "0.3.7-alpha.2",
+  "version": "0.3.7",
   "description": "The Internet Archive Donation Form Edit Donation component",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",

--- a/packages/edit-donation/package.json
+++ b/packages/edit-donation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/donation-form-edit-donation",
-  "version": "0.3.6",
+  "version": "0.3.7-alpha.2",
   "description": "The Internet Archive Donation Form Edit Donation component",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",

--- a/packages/edit-donation/src/donation-form-edit-donation.ts
+++ b/packages/edit-donation/src/donation-form-edit-donation.ts
@@ -140,6 +140,9 @@ export class DonationFormEditDonation extends LitElement {
       this.updateSelectedDonationInfo();
       this.setupAmountColumnsLayoutConfig();
     }
+    if (changedProperties.has('amountSelectionLayout')) {
+      this.setupAmountColumnsLayoutConfig();
+    }
     if (changedProperties.has('donationInfo')) {
       this.updateSelectedDonationInfo();
     }
@@ -252,7 +255,7 @@ export class DonationFormEditDonation extends LitElement {
       this.amountSelectionLayout ===
       EditDonationAmountSelectionLayout.SingleLine
     ) {
-      columnCount = 6;
+      columnCount = amountCount + 3;
       customAmountSpan = 3;
     }
 

--- a/packages/edit-donation/src/donation-form-edit-donation.ts
+++ b/packages/edit-donation/src/donation-form-edit-donation.ts
@@ -73,7 +73,7 @@ export class DonationFormEditDonation extends LitElement {
   @property({ type: Array }) amountOptions: number[] = defaultDonationAmounts;
 
   /**
-   * Layout the dollar amounts in a single line instead of two lines
+   * Layout the dollar amounts in a single line or multiple lines
    *
    * @memberof DonationFormEditDonation
    */
@@ -82,7 +82,7 @@ export class DonationFormEditDonation extends LitElement {
     EditDonationAmountSelectionLayout.MultiLine;
 
   /**
-   * Layout the
+   * Layout donation frequency choices as buttons or a checkbox
    *
    * @memberof DonationFormEditDonation
    */


### PR DESCRIPTION
Add some new layouts to the donation form:
- You can now replace the "One Time" / "Monthly" buttons with a "Make this monthly" checkbox
- The amount selector can now condense down to a single line

<img width="367" alt="Screen Shot 2021-09-09 at 11 58 58 AM" src="https://user-images.githubusercontent.com/51138/132746867-664495a0-db50-484c-8101-28ced3e79407.png">
<img width="366" alt="Screen Shot 2021-09-09 at 11 59 09 AM" src="https://user-images.githubusercontent.com/51138/132746881-a9dd6b9f-cb1d-4de6-ad02-5a1af076f9e3.png">
<img width="364" alt="Screen Shot 2021-09-09 at 11 59 18 AM" src="https://user-images.githubusercontent.com/51138/132746893-a24b80c7-3e5c-43f0-b23a-20bc549ddb88.png">
