### PR TITLE
WEBDEV-8585: Fix sticky customAmountSelected blocking programmatic donationInfo updates

### DIFF
--- a/packages/edit-donation/package.json
+++ b/packages/edit-donation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/donation-form-edit-donation",
-  "version": "1.1.5",
+  "version": "1.1.6-alpha.0",
   "description": "The Internet Archive Donation Form Edit Donation component",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",

--- a/packages/edit-donation/package.json
+++ b/packages/edit-donation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/donation-form-edit-donation",
-  "version": "1.1.6-alpha.1",
+  "version": "1.1.6",
   "description": "The Internet Archive Donation Form Edit Donation component",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",

--- a/packages/edit-donation/package.json
+++ b/packages/edit-donation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/donation-form-edit-donation",
-  "version": "1.1.6-alpha.0",
+  "version": "1.1.6-alpha.1",
   "description": "The Internet Archive Donation Form Edit Donation component",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",

--- a/packages/edit-donation/src/donation-form-edit-donation.ts
+++ b/packages/edit-donation/src/donation-form-edit-donation.ts
@@ -303,12 +303,21 @@ export class DonationFormEditDonation extends LitElement {
   }
 
   private updateSelectedDonationInfo(): void {
-    if (!this.customAmountSelected && !this.isCustomAmount) {
+    // keep the custom amount selected while the user is typing in it,
+    // even if the value matches a preset, so the selection doesn't
+    // jump to the preset radio mid-keystroke
+    const typingInCustomAmount =
+      this.shadowRoot?.activeElement === this.customAmountInput;
+    if (
+      !this.isCustomAmount &&
+      !(this.customAmountSelected && typingInCustomAmount)
+    ) {
       const radioButton = this.shadowRoot?.querySelector(
         `input[type="radio"][name="${EditDonationSelectionGroup.Amount}"][value="${this.donationInfo.amount}"]`,
       ) as HTMLInputElement;
       radioButton.checked = true;
       this.customAmountSelected = false;
+      this.error = undefined;
       if (this.customAmountInput) {
         this.customAmountInput.value = '';
       }

--- a/packages/edit-donation/src/donation-form-edit-donation.ts
+++ b/packages/edit-donation/src/donation-form-edit-donation.ts
@@ -325,7 +325,7 @@ export class DonationFormEditDonation extends LitElement {
       this.customAmountSelected = true;
       // don't update the value if it currently has focus
       // since the user may be typing in it at the time
-      if (this.shadowRoot?.activeElement !== this.customAmountInput) {
+      if (!typingInCustomAmount) {
         this.customAmountInput.value = this.customAmountDisplayValue;
         const donationInfoStatus = this.getDonationInfoStatus(
           this.donationInfo.amount,

--- a/packages/edit-donation/src/donation-form-edit-donation.ts
+++ b/packages/edit-donation/src/donation-form-edit-donation.ts
@@ -472,10 +472,7 @@ export class DonationFormEditDonation extends LitElement {
             @input=${this.customAmountChanged}
             @keydown=${this.currencyValidator.keydown}
             @focus=${this.customAmountFocused}
-            @blur=${(e: Event): void => {
-              const target = e.target as HTMLInputElement;
-              target.value = this.customAmountDisplayValue;
-            }}
+            @blur=${this.customAmountBlurred}
           />
         </label>
       </div>
@@ -490,6 +487,14 @@ export class DonationFormEditDonation extends LitElement {
     const target = e.target as HTMLInputElement;
     this.customAmountSelected = true;
     this.handleCustomAmountInput(target.value);
+  }
+
+  private customAmountBlurred(): void {
+    // the mid-keystroke typing protection no longer applies once focus
+    // leaves the field, so re-sync the UI with the donation info:
+    // demotes to the matching preset if the typed amount equals one,
+    // and re-formats the custom amount otherwise
+    this.updateSelectedDonationInfo();
   }
 
   private coverFeesChecked(e: Event): void {

--- a/packages/edit-donation/test/iaux-donation-form-edit-donation.test.ts
+++ b/packages/edit-donation/test/iaux-donation-form-edit-donation.test.ts
@@ -405,6 +405,40 @@ describe('EditDonation', () => {
       expect(preset5.checked).to.be.false;
     });
 
+    it('selects the matching preset on blur when the typed custom amount equals a preset', async () => {
+      const el = await fixture<DonationFormEditDonation>(html`
+        <donation-form-edit-donation
+          .donationInfo=${new MockDonationInfo()}
+        ></donation-form-edit-donation>
+      `);
+      const customRadioButton = el.shadowRoot?.querySelector(
+        '#custom-amount-button',
+      ) as HTMLInputElement;
+      const customInput = el.shadowRoot?.querySelector(
+        '#custom-amount-input',
+      ) as HTMLInputElement;
+
+      // type a preset-equal amount; custom stays selected while focused
+      customInput.focus();
+      customInput.value = '10';
+      customInput.dispatchEvent(new Event('input'));
+      await elementUpdated(el);
+      await elementUpdated(el);
+      expect(customRadioButton.checked).to.be.true;
+
+      // once focus leaves, the selection moves to the matching preset
+      customInput.blur();
+      await elementUpdated(el);
+      await elementUpdated(el);
+
+      const preset10 = el.shadowRoot?.querySelector(
+        '.amount-selector input[type=radio][value="10"]',
+      ) as HTMLInputElement;
+      expect(preset10.checked).to.be.true;
+      expect(customRadioButton.checked).to.be.false;
+      expect(customInput.value).to.equal('');
+    });
+
     it('keeps the custom amount selected while typing a preset-equal value', async () => {
       const el = await fixture<DonationFormEditDonation>(html`
         <donation-form-edit-donation

--- a/packages/edit-donation/test/iaux-donation-form-edit-donation.test.ts
+++ b/packages/edit-donation/test/iaux-donation-form-edit-donation.test.ts
@@ -337,6 +337,104 @@ describe('EditDonation', () => {
     expect(customInput?.value).to.equal('');
   });
 
+  describe('programmatic donationInfo updates', () => {
+    it('checks the matching preset when donationInfo is set while custom is selected', async () => {
+      // boot with a non-preset amount so the custom amount is selected
+      const el = await fixture<DonationFormEditDonation>(html`
+        <donation-form-edit-donation
+          defaultSelectedAmount="14"
+        ></donation-form-edit-donation>
+      `);
+      // let the cascading defaultSelectedAmount -> donationInfo ->
+      // customAmountSelected updates settle
+      await elementUpdated(el);
+      await elementUpdated(el);
+
+      const customRadioButton = el.shadowRoot?.querySelector(
+        '#custom-amount-button',
+      ) as HTMLInputElement;
+      const customInput = el.shadowRoot?.querySelector(
+        '#custom-amount-input',
+      ) as HTMLInputElement;
+      expect(customRadioButton.checked).to.be.true;
+      expect(customInput.value).to.equal('14.00');
+
+      el.donationInfo = new DonationPaymentInfo({
+        amount: 50,
+        donationType: DonationType.OneTime,
+        coverFees: false,
+      });
+      await elementUpdated(el);
+      await elementUpdated(el);
+
+      const preset50 = el.shadowRoot?.querySelector(
+        '.amount-selector input[type=radio][value="50"]',
+      ) as HTMLInputElement;
+      expect(preset50.checked).to.be.true;
+      expect(customRadioButton.checked).to.be.false;
+      expect(customInput.value).to.equal('');
+    });
+
+    it('selects the custom amount when donationInfo is set to a non-preset amount', async () => {
+      const el = await fixture<DonationFormEditDonation>(html`
+        <donation-form-edit-donation
+          .donationInfo=${new MockDonationInfo()}
+        ></donation-form-edit-donation>
+      `);
+      const customRadioButton = el.shadowRoot?.querySelector(
+        '#custom-amount-button',
+      ) as HTMLInputElement;
+      const customInput = el.shadowRoot?.querySelector(
+        '#custom-amount-input',
+      ) as HTMLInputElement;
+      expect(customRadioButton.checked).to.be.false;
+
+      el.donationInfo = new DonationPaymentInfo({
+        amount: 37,
+        donationType: DonationType.OneTime,
+        coverFees: false,
+      });
+      await elementUpdated(el);
+      await elementUpdated(el);
+
+      const preset5 = el.shadowRoot?.querySelector(
+        '.amount-selector input[type=radio][value="5"]',
+      ) as HTMLInputElement;
+      expect(customRadioButton.checked).to.be.true;
+      expect(customInput.value).to.equal('37.00');
+      expect(preset5.checked).to.be.false;
+    });
+
+    it('keeps the custom amount selected while typing a preset-equal value', async () => {
+      const el = await fixture<DonationFormEditDonation>(html`
+        <donation-form-edit-donation
+          .donationInfo=${new MockDonationInfo()}
+        ></donation-form-edit-donation>
+      `);
+      const customRadioButton = el.shadowRoot?.querySelector(
+        '#custom-amount-button',
+      ) as HTMLInputElement;
+      const customInput = el.shadowRoot?.querySelector(
+        '#custom-amount-input',
+      ) as HTMLInputElement;
+
+      // user types "5" into the custom amount field; 5 is a preset,
+      // but the selection should not jump to the preset mid-keystroke
+      customInput.focus();
+      customInput.value = '5';
+      customInput.dispatchEvent(new Event('input'));
+      await elementUpdated(el);
+      await elementUpdated(el);
+
+      const preset5 = el.shadowRoot?.querySelector(
+        '.amount-selector input[type=radio][value="5"]',
+      ) as HTMLInputElement;
+      expect(customRadioButton.checked).to.be.true;
+      expect(customInput.value).to.equal('5');
+      expect(preset5.checked).to.be.false;
+    });
+  });
+
   describe('configurable dollar amounts', () => {
     it('supports configurable dollar amounts', async () => {
       const el = await fixture<DonationFormEditDonation>(html`


### PR DESCRIPTION
## Summary

Fixes [WEBDEV-8585](https://webarchive.jira.com/browse/WEBDEV-8585): setting the public `donationInfo` property on `<donation-form-edit-donation>` while the custom amount was selected left the custom pill selected with an **empty** input, and the matching preset radio never got checked — even though `donationInfo.amount` held the new value.

### Root cause

`updateSelectedDonationInfo()` treated the private `customAmountSelected` state as sticky — once `true` it was never demoted, so every external `donationInfo` write landed in the custom branch, where `customAmountDisplayValue` returns `''` for preset amounts. `presetAmountsTemplate` also gates preset `checked` on `!customAmountSelected`, so the preset couldn't highlight either.

### Fix

Derive the branch from `isCustomAmount` (the actual data) instead of the sticky flag, demoting custom when the new amount matches a preset — **except** while the user is actively typing in the custom input, so typing a preset-equal value like "5" doesn't yank the selection over to the preset radio mid-keystroke. Also clears any stale amount error when a programmatic write lands on a preset, mirroring `presetAmountChanged()`.

### Tests

- Regression test for the ticket's repro: boot via `defaultSelectedAmount="14"` (custom selected), set `donationInfo` to a preset amount (50) → preset checked, custom pill unchecked, custom input cleared. **Verified this test fails against the unfixed code.**
- Programmatic write to a non-preset amount still selects custom and fills the input.
- Typing-protection retained: typing "5" (preset-equal) in the focused custom input keeps custom selected with the raw value intact.

### Consumer impact

petabox currently works around this by poking the private state ([commit 1fb4a886f7](https://git.archive.org/ia/petabox/-/commit/1fb4a886f7)) for the WEBDEV-8405 paired banners — that workaround can be removed once this ships and the package is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WEBDEV-8585]: https://webarchive.jira.com/browse/WEBDEV-8585?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ