### PR TITLE
WEBDEV-8603: Update edit-donation dep to 1.1.6

### DIFF
--- a/packages/donation-form/package.json
+++ b/packages/donation-form/package.json
@@ -31,7 +31,7 @@
     "@internetarchive/analytics-manager": "^0.1.4",
     "@internetarchive/donation-form-currency-validator": "^0.3.1",
     "@internetarchive/donation-form-data-models": "^0.3.6",
-    "@internetarchive/donation-form-edit-donation": "^1.1.5",
+    "@internetarchive/donation-form-edit-donation": "^1.1.6",
     "@internetarchive/donation-form-section": "^0.3.6",
     "@internetarchive/icon-applepay": "^1.3.2",
     "@internetarchive/icon-calendar": "^1.3.2",

--- a/packages/donation-form/package.json
+++ b/packages/donation-form/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@internetarchive/donation-form",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "The Internet Archive Donation Form",
   "license": "AGPL-3.0-only",
   "main": "dist/index.js",

--- a/packages/donation-form/yarn.lock
+++ b/packages/donation-form/yarn.lock
@@ -300,10 +300,10 @@
   resolved "https://registry.yarnpkg.com/@internetarchive/donation-form-data-models/-/donation-form-data-models-0.3.6.tgz#69de1ddc4b2de5864d3405d5d47243314a1f7ade"
   integrity sha512-uc+HOTYpF+BoKVktAJIOh5mCS3unBEJkpdTNV5NfxtBX4IH1POgY+G81/3mOZK6RjNtTeG9muKhDY/DLvLBIvA==
 
-"@internetarchive/donation-form-edit-donation@^1.1.5":
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/@internetarchive/donation-form-edit-donation/-/donation-form-edit-donation-1.1.5.tgz#b1e7559dfa156ddef60186e2c89cf09d6df438ef"
-  integrity sha512-nx700dSQCDDJHe1kuA91CCkz00yNt/rIsuyEN3+PtbI885f429+sLXe4/U29lc3SP3oQpTKieocWGUCUKKY0UQ==
+"@internetarchive/donation-form-edit-donation@^1.1.6":
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/@internetarchive/donation-form-edit-donation/-/donation-form-edit-donation-1.1.6.tgz#415c27759be835aaf4ee4d0b25d8c5df0de96d3b"
+  integrity sha512-mZY+f5qWvOA+xCNYYBwBH06mHNZ47QveFUF0Sge03l/kD5Rj2G7XpSwDxhTpieMpGVeeAMTIvOQSAcjNP7glGw==
   dependencies:
     "@internetarchive/donation-form-currency-validator" "^0.3.1"
     "@internetarchive/donation-form-data-models" "^0.3.6"


### PR DESCRIPTION
## Summary

Bumps `@internetarchive/donation-form-edit-donation` from `^1.1.5` to `^1.1.6` in `packages/donation-form`, delivering the WEBDEV-8585 fix (sticky `customAmountSelected` blocking programmatic `donationInfo` updates, #184) to the donation form, and bumps donation-form to 1.0.5 for release.

Tracked in [WEBDEV-8603](https://webarchive.jira.com/browse/WEBDEV-8603) (split out of WEBDEV-8585 for separate review — hence the branch name).

- `packages/donation-form/package.json`: edit-donation `^1.1.5` → `^1.1.6`; version `1.0.4` → `1.0.5`
- `packages/donation-form/yarn.lock`: resolves edit-donation 1.1.6

## Test plan

- `yarn test` in `packages/donation-form`: tsc, eslint/prettier, circular-dep check, and 86/86 web-test-runner tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[WEBDEV-8603]: https://webarchive.jira.com/browse/WEBDEV-8603?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ