### PR TITLE
WEBDEV-8781: Guard localStorage/sessionStorage access in VenmoRestorationStateHandler

### DIFF
--- a/packages/donation-form/src/payment-flow-handlers/handlers/venmo-restoration-state-handler.ts
+++ b/packages/donation-form/src/payment-flow-handlers/handlers/venmo-restoration-state-handler.ts
@@ -64,13 +64,10 @@ export class VenmoRestorationStateHandler implements VenmoRestorationStateHandle
   private storageSystem?: Storage;
 
   constructor(options?: { storageSystem?: Storage }) {
-    if (options?.storageSystem) {
-      this.storageSystem = options.storageSystem;
-    } else if (this.storageSystemAvailable(localStorage)) {
-      this.storageSystem = localStorage;
-    } else if (this.storageSystemAvailable(sessionStorage)) {
-      this.storageSystem = sessionStorage;
-    }
+    this.storageSystem =
+      options?.storageSystem ??
+      this.getAvailableStorageSystem(() => localStorage) ??
+      this.getAvailableStorageSystem(() => sessionStorage);
   }
 
   /** @inheritdoc */
@@ -108,20 +105,23 @@ export class VenmoRestorationStateHandler implements VenmoRestorationStateHandle
   }
 
   /**
-   * Check if a particular storage system (localStorage/sessionStorage) is availble
+   * Resolve and probe a storage system (localStorage/sessionStorage), returning it if
+   * usable. Guards against browsers (e.g. Safari private browsing) that throw
+   * synchronously just from accessing the storage global, not only from using it.
    *
    * @private
-   * @param {Storage} system
-   * @returns {boolean}
+   * @param {() => Storage} getSystem
+   * @returns {(Storage | undefined)}
    * @memberof VenmoRestorationStateHandler
    */
-  private storageSystemAvailable(system: Storage): boolean {
+  private getAvailableStorageSystem(getSystem: () => Storage): Storage | undefined {
     try {
+      const system = getSystem();
       system.setItem('foo', 'bar');
       system.removeItem('foo');
-      return true;
+      return system;
     } catch (exception) {
-      return false;
+      return undefined;
     }
   }
 }

--- a/packages/donation-form/test/tests/flow-handlers/venmo-restoration-state-handler.test.ts
+++ b/packages/donation-form/test/tests/flow-handlers/venmo-restoration-state-handler.test.ts
@@ -1,0 +1,40 @@
+import { expect } from '@open-wc/testing';
+import sinon from 'sinon';
+import { VenmoRestorationStateHandler } from '../../../src/payment-flow-handlers/handlers/venmo-restoration-state-handler';
+
+describe('VenmoRestorationStateHandler', () => {
+  afterEach(() => {
+    sinon.restore();
+  });
+
+  it('does not throw when accessing localStorage/sessionStorage throws (e.g. Safari private browsing)', () => {
+    sinon.stub(window, 'localStorage').get(() => {
+      throw new DOMException('The operation is insecure.', 'SecurityError');
+    });
+    sinon.stub(window, 'sessionStorage').get(() => {
+      throw new DOMException('The operation is insecure.', 'SecurityError');
+    });
+
+    expect(() => new VenmoRestorationStateHandler()).to.not.throw();
+  });
+
+  it('falls back to sessionStorage when localStorage is unavailable', () => {
+    sinon.stub(window, 'localStorage').get(() => {
+      throw new DOMException('The operation is insecure.', 'SecurityError');
+    });
+
+    const handler = new VenmoRestorationStateHandler();
+    handler.clearState();
+    expect(() => handler.clearState()).to.not.throw();
+  });
+
+  it('uses the provided storageSystem when given', () => {
+    const storageSystem = window.sessionStorage;
+    const handler = new VenmoRestorationStateHandler({ storageSystem });
+    const removeItemSpy = sinon.spy(storageSystem, 'removeItem');
+
+    handler.clearState();
+
+    expect(removeItemSpy.calledWith('venmoRestorationStateInfo')).to.be.true;
+  });
+});


### PR DESCRIPTION
## Summary
- `VenmoRestorationStateHandler`'s constructor referenced `localStorage`/`sessionStorage` as bare globals before entering the try/catch in `storageSystemAvailable()`. Safari (private browsing) throws a `SecurityError` synchronously on that property access alone, so the throw escaped uncaught.
- Renamed to `getAvailableStorageSystem`, which now evaluates the global access *inside* the guarded probe, so both the access and the `setItem`/`removeItem` check are caught.

Fixes #187, tracked downstream as [WEBDEV-8781](https://webarchive.jira.com/browse/WEBDEV-8781).

## Test plan
- [x] `tsc` build passes
- [x] Added `venmo-restoration-state-handler.test.ts` covering: throwing-getter case (Safari private browsing simulation), localStorage→sessionStorage fallback, and explicit `storageSystem` override
- [x] Full suite: 118 passing (up from 115), same 5 pre-existing/unrelated failures before and after this change

[WEBDEV-8781]: https://webarchive.jira.com/browse/WEBDEV-8781?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ